### PR TITLE
added timeout for requests on monitoring

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -125,6 +125,7 @@ class AppleStoreMonitor:
 
     def __init__(self):
         self.count = 1
+        self.timeout = 10
 
     @staticmethod
     def config():
@@ -321,7 +322,8 @@ class AppleStoreMonitor:
 
                 response = requests.get("https://www.apple.com.cn/shop/fulfillment-messages",
                                         headers=AppleStoreMonitor.headers,
-                                        params=params)
+                                        params=params,
+                                        timeout=self.timeout)
 
                 json_result = json.loads(response.text)
                 stores = json_result['body']['content']['pickupMessage']['stores']


### PR DESCRIPTION
在程序监控过程中，可能遇到与www.apple.com.cn连接不稳定，
会导致程序一直等待requests返回而卡死，
在实际运行中表现为：
    控制台打印出：“x秒后进行第y次尝试...” 之后不再有反应，
所以可以加上timeout参数，超出timeout时间之后抛出异常，
捕获之后程序可以继续正常运行。