### PR TITLE
Add Email Notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 - [x] 可配置在程序发生异常时是否发送通知。
 - [x] 增加Bark推送【仅iOS】，感谢[zh616110538](https://github.com/zh616110538)。[【PR #2】](https://github.com/LennonChin/AppleStore-Monitor/pull/2)
 - [x] 修复未选择排除的直营店时出现的异常。
+- [x] 增加邮件通知，配合iOS快捷指令可完成闹钟、拨打电话的功能。
+- [x] 可配置在有货时重复发送通知
 
 # 安装
 

--- a/apple_store_monitor_configs.json
+++ b/apple_store_monitor_configs.json
@@ -1,22 +1,12 @@
 {
   "selected_products": {
-    "MGYJ3CH/A": [
-      "AirPods Max",
-      "AirPods Max - 银色"
-    ],
-    "MLHG3CH/A": [
-      "iPhone 13 Pro Max",
-      "512GB 远峰蓝色"
+    "MTQD3CH/A": [
+      "iPhone 15 Pro",
+      "512GB \u9ed1\u8272\u949b\u91d1\u5c5e"
     ]
   },
-  "selected_area": "上海 上海 黄浦区",
-  "exclude_stores": [
-    "R688",
-    "R574",
-    "R531",
-    "R532",
-    "R471"
-  ],
+  "selected_area": "\u5317\u4eac \u5317\u4eac \u4e1c\u57ce\u533a",
+  "exclude_stores": [],
   "notification_configs": {
     "dingtalk": {
       "access_token": "",
@@ -37,8 +27,16 @@
         "automaticallyCopy": null,
         "copy": null
       }
+    },
+    "email": {
+      "to_email": "",
+      "smtp_server": "",
+      "smtp_port": "",
+      "smtp_username": "",
+      "smtp_password": ""
     }
   },
   "scan_interval": 30,
-  "alert_exception": false
+  "alert_exception": false,
+  "always_alert": false
 }

--- a/monitor.py
+++ b/monitor.py
@@ -429,13 +429,13 @@ class AppleStoreMonitor:
                     print(
                         "命中货源，请注意 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
                     if always_alert or self.alter_swc:
+                        self.history.append(datetime.datetime.now())
                         Utils.send_message(notification_configs,
                                            Utils.subject_title(
                                                "{}有货通知".format(available_stores),
                                                "第{}次扫描到直营店有货，信息如下：\n{}".format(self.count,
                                                                                              "\n".join(messages))))
                     self.alter_swc = False
-                    self.history.append(datetime.datetime.now())
                 else:
                     if not self.alter_swc:
                         not_available_time = datetime.datetime.now()
@@ -447,7 +447,7 @@ class AppleStoreMonitor:
                                            Utils.subject_title(
                                                "监测的货物已售罄！",
                                                "本次放货时间:{}\n售罄时间:{}\n共持续:{}{}{}"
-                                               .format(available_time.strftime("%Y年%m月%d日 %H:%M:%S"), not_available_time.strftime("%Y年%m月%d日 %H:%M:%S"),
+                                               .format(self.history[-1].strftime("%Y年%m月%d日 %H:%M:%S"), not_available_time.strftime("%Y年%m月%d日 %H:%M:%S"),
                                                        hours and str(hours) + "小时" or "", minutes and str(minutes) + "分" or "", seconds and str(seconds) + "秒" or "")))
                     self.alter_swc = True
 


### PR DESCRIPTION
增加了通知标题（Apple Store监控开始通知、Apple Store监控运行通知、Apple Store监控异常通知、XXX直营店有货通知、监测的货物已售罄）；
增加了邮件通知；
![image](https://github.com/LennonChin/AppleStore-Monitor/assets/43309271/e94c9e30-c663-475b-8225-70868d3bd72e)
增加了售罄提醒以及时间摘要以供后续抢购参考；
![image](https://github.com/LennonChin/AppleStore-Monitor/assets/43309271/a283d18f-2187-4923-b782-d9551017a395)
将重复提醒设置为一个可配置参数，关闭后有货时不会重复提醒，在商品售罄后会继续提醒。